### PR TITLE
fix #contains_point? to support holes in timezone

### DIFF
--- a/spec/wheretz_spec.rb
+++ b/spec/wheretz_spec.rb
@@ -36,6 +36,10 @@ describe WhereTZ do
     context 'when timezone name contains hypen(-) char' do
       its_call(64.56027, 143.22666) { is_expected.to ret 'Asia/Ust-Nera' }
     end
+
+    context 'when timezone has a hole' do
+      its_call(35.93, -110.60) { is_expected.to ret 'America/Phoenix' }
+    end
   end
 
   describe '#get' do


### PR DESCRIPTION
Thanks for the gem! Here's a fix for an interesting edge case I ran across.

Fix #contains_point? to properly handle Polygons with multiple rings. Every
ring after the first represents a hole in the first ring. This is rare but can
be seen currently in America/Denver.

![image](https://user-images.githubusercontent.com/1438495/123847596-62631f00-d8dc-11eb-8bd5-23a39eaf1d39.png)

Prior to this change the hole matched both America/Denver and America/Phoenix.

As per the GeoJSON spec[1]:

> For Polygons with multiple rings, the first must be the exterior ring and any
> others must be interior rings or holes.

1. https://geojson.org/geojson-spec.html